### PR TITLE
Add BP3+ getting started tutorial library to package manager

### DIFF
--- a/Index.xml
+++ b/Index.xml
@@ -59,9 +59,9 @@
     name="BurnP3PlusFireSTARR Quickstart Tutorial"
     displayName="Quickstart Tutorial"
     description="BurnP3+ tutorial library using the FireSTARR fire growth model"
-    libraryLocation="https://s3.ca-central-1.amazonaws.com/apexrms.com.syncrosim.templates/BurnP3PlusFireSTARR/v1.5.7/BurnP3PlusFireSTARR Quickstart Tutorial (Alberta).ssimbak"
+    libraryLocation="https://s3.ca-central-1.amazonaws.com/apexrms.com.syncrosim.templates/BurnP3PlusFireSTARR/v1.5.7/BurnP3PlusFireSTARR%20Quickstart%20Tutorial%20%28Alberta%29.ssimbak"
     imageLocation="https://s3.ca-central-1.amazonaws.com/apexrms.com.syncrosim.templates/BurnP3PlusFireSTARR/v1.5.7/glacier-example.png">
-  </onlineLibrary>
+    </onlineLibrary>
   </package>
   <package
     name="burnP3PlusPrometheus"

--- a/Index.xml
+++ b/Index.xml
@@ -55,6 +55,13 @@
       libraryLocation="https://s3.ca-central-1.amazonaws.com/apexrms.com.syncrosim.templates/BurnP3PlusFireSTARR/v1.5.7/firestarr-example.ssimbak"
       imageLocation="https://s3.ca-central-1.amazonaws.com/apexrms.com.syncrosim.templates/BurnP3PlusFireSTARR/v1.5.7/glacier-example.png">
     </onlineLibrary>
+    <onlineLibrary 
+    name="BurnP3PlusFireSTARR Quickstart Tutorial"
+    displayName="Quickstart Tutorial"
+    description="BurnP3+ tutorial library using the FireSTARR fire growth model"
+    libraryLocation="https://s3.ca-central-1.amazonaws.com/apexrms.com.syncrosim.templates/BurnP3PlusFireSTARR/v1.5.7/BurnP3PlusFireSTARR Quickstart Tutorial (Alberta).ssimbak"
+    imageLocation="https://s3.ca-central-1.amazonaws.com/apexrms.com.syncrosim.templates/BurnP3PlusFireSTARR/v1.5.7/glacier-example.png">
+  </onlineLibrary>
   </package>
   <package
     name="burnP3PlusPrometheus"

--- a/burnP3PlusFireSTARR-1.5.7/metadata.xml
+++ b/burnP3PlusFireSTARR-1.5.7/metadata.xml
@@ -12,4 +12,11 @@
     libraryLocation="https://s3.ca-central-1.amazonaws.com/apexrms.com.syncrosim.templates/BurnP3PlusFireSTARR/v1.5.7/firestarr-example.ssimbak"
     imageLocation="https://s3.ca-central-1.amazonaws.com/apexrms.com.syncrosim.templates/BurnP3PlusFireSTARR/v1.5.7/glacier-example.png">
   </onlineLibrary>
+  <onlineLibrary 
+    name="BurnP3PlusFireSTARR Quickstart Tutorial"
+    displayName="Quickstart Tutorial"
+    description="BurnP3+ tutorial library using the FireSTARR fire growth model"
+    libraryLocation="https://s3.ca-central-1.amazonaws.com/apexrms.com.syncrosim.templates/BurnP3PlusFireSTARR/v1.5.7/BurnP3PlusFireSTARR Quickstart Tutorial (Alberta).ssimbak"
+    imageLocation="https://s3.ca-central-1.amazonaws.com/apexrms.com.syncrosim.templates/BurnP3PlusFireSTARR/v1.5.7/glacier-example.png">
+  </onlineLibrary>
 </package>

--- a/burnP3PlusFireSTARR-1.5.7/metadata.xml
+++ b/burnP3PlusFireSTARR-1.5.7/metadata.xml
@@ -16,7 +16,7 @@
     name="BurnP3PlusFireSTARR Quickstart Tutorial"
     displayName="Quickstart Tutorial"
     description="BurnP3+ tutorial library using the FireSTARR fire growth model"
-    libraryLocation="https://s3.ca-central-1.amazonaws.com/apexrms.com.syncrosim.templates/BurnP3PlusFireSTARR/v1.5.7/BurnP3PlusFireSTARR Quickstart Tutorial (Alberta).ssimbak"
+    libraryLocation="https://s3.ca-central-1.amazonaws.com/apexrms.com.syncrosim.templates/BurnP3PlusFireSTARR/v1.5.7/BurnP3PlusFireSTARR%20Quickstart%20Tutorial%20%28Alberta%29.ssimbak"
     imageLocation="https://s3.ca-central-1.amazonaws.com/apexrms.com.syncrosim.templates/BurnP3PlusFireSTARR/v1.5.7/glacier-example.png">
   </onlineLibrary>
 </package>


### PR DESCRIPTION
## Important note for PR reviewers

**Before merging the PR, please rebuild the package index using the [rebuild-metadata.ps1](https://github.com/ApexRMS/syncrosim3/blob/main/scripts/rebuild-metadata.ps1) script**

This is a new tutorial library featured on the updated BP3+ Getting Started landing page that replaces the old Cell2Fire example with FireSTARR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new online library entry for the **BurnP3PlusFireSTARR Quickstart Tutorial**.
  * Included updated display text, description, and links to the tutorial content and preview image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->